### PR TITLE
SpotifyAPI 1.0.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Debug main.py",
+            "type": "debugpy",
+            // "python": "${workspaceFolder}/.venv/Scripts/python.exe",
+            "request": "launch",
+            "program": "${workspaceFolder}/main.py",
+            "justMyCode": true
+        },
+        {
+            "name": "Python: Import Spotify Data",
+            "type": "debugpy",
+            "python": "${workspaceFolder}/.venv/Scripts/python.exe",
+            "request": "launch",
+            "program": "${workspaceFolder}/import_spotify_data.py",
+            "args": ["Stan"],
+            "justMyCode": true
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+## SpotifyAPI
+- See your all-time favorites
+- Generate lost song candidates
+- Programmatically create playlists
+
+### Example Use
+Ever lose a beloved song? Create a Spotify playlist of lost song candidates (lifetime_listening_record - liked_songs):
+```
+NAME = "Stan"	# same name from import step: `py ./import_Spotify_Data.py {name}`
+lost_song_candidates = SpotifyUser(NAME).lost_song_candidates(minimum_listen_time_in_minutes=60)
+
+SaveToPlaylistRequest.New_Playlist(
+	playlist_name,
+	description="",
+	public=True
+).Handle(lost_song_candidates).Result()
+```
+
+### Steps to run above code: 
+- Spotify Data, types:
+	- **Account Data** - ***[REQUIRED]***
+	- **Extended Streaming History** - ***[REQUIRED]***
+	- Technical Log
+- Spotify Data, where:
+  	- https://www.spotify.com/us/account/privacy/ - USA Accounts Direct Link
+- `py ./import_Spotify_Data.py {name}`
+    - `name`: owner of the Spotify Data. separate `*.zips` will be categorized under this name
+    - find `my_spotify_data.zip` through the File Chooser
+ - **Enable Spotify Web Api Interactions**
+ 	- click on (**Create app**) on the [Developer Dashboard](https://developer.spotify.com/dashboard)
+    	- *Redirect URI*: *`http://127.0.0.1:8080/callback`*
+  	- The new App's `Client ID` and `client secret` need to be copy/pasted into the template `./.env`:
+	    ```
+		client_id=
+		client_secret=
+	    ```

--- a/Spotify User Data/directory.note
+++ b/Spotify User Data/directory.note
@@ -1,0 +1,12 @@
+This directory is SPOTIFY_USER_DATA_DIR [definitions.py]
+
+Is container for Spotify_Data_Types [Spotify_Data_Types.py] 
+	Imported via: `py ./import_Spotify_Data.py {name}`
+
+Ingested during SpotifyUser() [spotify_py/SpotifyUser.py] instantiation to 
+	Find statistical insights, compare different data owners
+
+
+Entire Spotify Lifetime Listening Record
+	- can ONLY be acquired through this offline data, specifically:
+	- Spotify Extended Streaming History, see: Spotify_Data_Types.py

--- a/Spotify_Data_Types.py
+++ b/Spotify_Data_Types.py
@@ -1,0 +1,18 @@
+from enum import StrEnum
+
+
+class Spotify_Data_Type(StrEnum):
+    """
+    The name of folder inside: `my_spotify_data.zip`, holding the data.
+
+    Acquire/Use: `my_spotify_data.zip`
+    -----------------------------
+    1. Download zip(s) at: https://www.spotify.com/us/account/privacy/
+    2. `py ./import_Spotify_Data.py {name}` **OR**
+    3. call: `Import_Spotify_Data(name, absolute_path_to_zip)`
+
+    Data Details:  https://support.spotify.com/us/article/understanding-your-data/
+    """
+    ACCOUNT_DATA               = 'Spotify Account Data'
+    EXTENDED_STREAMING_HISTORY = 'Spotify Extended Streaming History'
+    TECHNICAL_LOG              = 'Spotify Technical Log Information'

--- a/definitions.py
+++ b/definitions.py
@@ -1,0 +1,22 @@
+import os
+
+
+APP_NAME = 'SpotifyApi'
+
+#----- Spotify Web API / Spotify Authorization Code Flow ---------------------------------#
+REDIRECT_URI      = 'http://127.0.0.1:8080/callback'
+PERMISSION_SCOPES = 'playlist-read-private playlist-read-collaborative user-library-read user-library-modify playlist-modify-public user-top-read'
+
+
+#----- Absolute Paths to Project Directories / Config Files ---------------------------------------------#
+PROJECT_ROOT_DIRECTORY =  os.path.dirname(os.path.abspath(__file__))
+SPOTIFY_USER_DATA_DIR  =  os.path.join(PROJECT_ROOT_DIRECTORY, 'Spotify User Data')
+ENV                    =  os.path.join(PROJECT_ROOT_DIRECTORY, '.env')
+
+
+#----- Spotify User Data :: Data Owners ---------------------------------------------#
+STAN = os.path.join(PROJECT_ROOT_DIRECTORY, 'Spotify User Data', 'Stan')
+LUNA = os.path.join(PROJECT_ROOT_DIRECTORY, 'Spotify User Data', 'Luna')
+
+
+TEMP_DIR = os.path.join(PROJECT_ROOT_DIRECTORY, 'temp')

--- a/import_spotify_data.py
+++ b/import_spotify_data.py
@@ -1,0 +1,131 @@
+"""
+`py ./import_Spotify_Data.py {name}`
+    `{name}:str` -> owner of the Spotify Data. Separate `*.zips` will be categorized under this name. See: `SpotifyUser`
+
+Spotify Data Types:
+    - Spotify Account Data
+    - Spotify Extended Streaming History
+    - Spotify Technical Log Information
+"""
+import os, argparse
+from typing import Optional
+from tkinter import Tk, filedialog
+from zipfile import ZIP_LZMA, ZipFile
+from kozubenko.datetime import local_time_as_legal_filename
+from kozubenko.print import Print
+from kozubenko.os import Directory, Downloads_Directory, File
+from spotify_py.SpotifyUser import USER_DATA_DIR
+from Spotify_Data_Types import Spotify_Data_Type
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('name', nargs='?', help='owner of the Spotify Data. Separate `*.zips` [Spotify Data Types] will be categorized under this name.')
+    args = parser.parse_args()
+
+    if not args.name:
+        Print.red('import_Spotify_Data.py: name {arg1} is required. For details, run: `py import_Spotify_Data.py --help`')
+        exit(0)
+
+
+class Test:
+    def archive_has_correctly_zipped_all_old_files(data_directory:Directory, archive_dest:Directory) -> bool:
+        original_file_names:set[str] = set()
+
+        for file in data_directory.files():
+            original_file_names.add(file.name)
+
+        for file in ZipFile(archive_dest, 'r').namelist():
+            if not File(file).name in original_file_names:
+                return False
+
+        return True
+
+def archive(name:str, data_type:Spotify_Data_Type) -> Directory:
+    """
+    Caller should check if `archive()` necessary. Will throw if request
+
+    **Returns:**
+        - If zipped folder absolute path 
+    """
+    data_to_archive = USER_DATA_DIR(name, data_type)
+    DESTINATION = Directory(USER_DATA_DIR(name), 'ARCHIVE', data_type, f'{local_time_as_legal_filename()}.zip')
+
+    if not data_to_archive.empty():
+        with ZipFile(DESTINATION.ensure_parents(), 'w', compression=ZIP_LZMA) as zip:
+            for file in data_to_archive.files():
+                zip.write(file, os.path.relpath(file, file.parent.parent))
+
+        return DESTINATION
+    
+    return Exception(f'archive(name={name}, data_type={data_type}): archive() called on an empty Directory')
+
+def identify_Spotify_Data_Type(zip:ZipFile) -> Spotify_Data_Type | Exception:
+    """
+    Identified by the root folder in 'my_spotify_data.zip'
+        name of root folder == `Spotify_Data_Type`
+
+    Remarks:
+    --------
+    **`zip.namelist()` Returns:**
+        Spotify Extended Streaming History/Streaming_History_Audio_2016-2018_0.json
+        ...
+        Spotify Extended Streaming History/Streaming_History_Video_2018-2026.json
+        Spotify Extended Streaming History/
+        Spotify Extended Streaming History/ReadMeFirst_ExtendedStreamingHistory.pdf
+
+    `containing_folder` -> "Spotify Extended Streaming History"
+    """
+    root_folder_name = zip.namelist()[0].split('/', maxsplit=1)[0]
+
+    if root_folder_name in Spotify_Data_Type:
+        return Spotify_Data_Type(root_folder_name)
+    
+    raise Exception('identify_Spotify_Data_Type(): Given .zip does not contain a standard Spotify_Data_Type!')
+
+def Import_Spotify_Data(name:str, path_to_zip:Optional[str]=None) -> None | Exception:
+    """
+    Unzips only jsons from 'my_spotify_data.zip' to avoid extraneous files, e.g. readme.pdf
+
+    **Parameters**:
+        - `name` - data owner/username. Becomes name of the folder under which data is stored.
+        - `path_to_zip` - path to 'my_spotify_data.zip'. If not provided, filedialog opens for user to manually select .zip.
+    """
+    if path_to_zip is None:
+        root = Tk()
+        root.attributes('-topmost',True, '-alpha',0)
+        path_to_zip = filedialog.askopenfilename(initialdir=Downloads_Directory(), title='Select my_spotify_data*.zip', filetypes=[('zip files', '*.zip')])
+
+    zip = ZipFile(path_to_zip, 'r')
+    data_type = identify_Spotify_Data_Type(zip)
+    data_dest = Directory(USER_DATA_DIR(name), data_type)   # i.e: ./Spotify User Data/{name}/{Spotify_Data_Type}
+
+    if data_dest.exists() and not data_dest.empty():
+        archive_dest:Directory = archive(name, data_type)
+        if not Test.archive_has_correctly_zipped_all_old_files(data_dest, archive_dest):
+            raise Exception('Import_Spotify_Data(): Cannot Proceed, TEST FAILED!')
+        archive_dest.delete()
+    else:
+        archive_dest = None
+
+    for file in zip.namelist():   # e.g: "Spotify Extended Streaming History/Streaming_History_Audio_2016-2018_0.json"
+        if file.endswith('.json'):
+            zip.extract(file, data_dest.parent)   # root_folder in my_spotify_data.zip IS destination, thus destination.parent passed in as alternate `path` 
+
+    zip.close()
+
+    Print.green(f'Import_Spotify_Data(name={name}, path_to_zip={path_to_zip}): SUCCESS!')
+    Print.green(f'   data_type = {data_type}')
+    Print.green(f'   data_dest = {data_dest}')
+    if archive_dest:
+        Print.green(f'   old data archived to = {archive_dest}')
+
+
+
+if __name__ == "__main__":
+    Import_Spotify_Data(args.name)
+
+
+
+

--- a/kozubenko/OAuth2.py
+++ b/kozubenko/OAuth2.py
@@ -1,0 +1,27 @@
+import string
+from .random import Random
+
+
+class OAuth2():
+    def generate_state() -> str:
+        """
+        `state` - an Optional, but strongly recommended param in `OAuth2` `Authorization Code Flow` (prevents cross-site request forgeries. See: `RFC-6749`)
+
+        uses `Random.string` under the hood, `_len` and `_from` set to the ideal params
+
+        **Example:**
+        >>> if not Env.loaded: Env.Load()
+        >>> params = {
+            'response_type': 'code',
+            'client_id': Env.vars['client_id'],
+            'scope': Env.vars['scope'],
+            'redirect_uri': Env.vars['redirect_uri'],
+            'state': OAuth2.generate_state()
+        }
+        
+        >>> return redirect('https://accounts.spotify.com/authorize?' + urllib.parse.urlencode(params))
+        """
+        _len = 16
+        _from = string.ascii_letters+string.digits
+
+        return Random.string(_len, _from)

--- a/kozubenko/datetime.py
+++ b/kozubenko/datetime.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+
+def local_time_as_legal_filename() -> str:
+    """
+    **Returns:**
+        - `datetime.now()` string in format that won't throw exception if used as filename
+        e.g: `2025-03-18 16:30:55`
+    """
+    return datetime.now().strftime('%Y-%m-%d %H.%M.%S')

--- a/kozubenko/env.py
+++ b/kozubenko/env.py
@@ -1,0 +1,48 @@
+import os, threading
+from definitions import ENV
+
+
+class Env:
+    Vars = {}
+    PATH_TO_ENV_FILE = ENV
+    loaded = False
+    mutex = threading.Lock()
+
+    def Load(keys_to_delete = []):
+        Env.Vars = {}
+        if os.path.exists(Env.PATH_TO_ENV_FILE):
+            with open(Env.PATH_TO_ENV_FILE, 'r') as file:
+                for line in file:
+                    if '=' in line:                                     # Each line must have a "=", truthy (string) key,value, to be written into the record
+                        key, value = (line.strip()).split('=', 1)       
+                        if key and key not in keys_to_delete:
+                            Env.Vars[key] = value
+        Env.overwrite()
+        Env.loaded = True
+
+    def Save(data:dict|str, value:str=None):
+        """ Supports saving either a single `key`/`value`, or saving a `dict` of `data` """
+        if Env.loaded is False: Env.Load()
+        Env.mutex.acquire()
+
+        if isinstance(data, dict):
+            for k, v in data.items():
+                if k and v: Env.Vars[k] = v
+
+        elif data and value:
+            Env.Vars[data] = value
+
+        Env.overwrite()
+        Env.mutex.release()
+
+    def Delete(key:str|list):
+        if(isinstance(key, str)): key=[key]
+        Env.Load(ENV, keys_to_delete=key)
+
+    def overwrite():
+        directory = os.path.dirname(Env.PATH_TO_ENV_FILE)
+        if not os.path.exists(directory): os.makedirs(directory, exist_ok=True)
+        lines = ""
+        for key, value in Env.Vars.items(): lines += f'{key}={value}\n'
+        with open(Env.PATH_TO_ENV_FILE, 'w') as file:
+            file.write(lines[:-1])

--- a/kozubenko/html.py
+++ b/kozubenko/html.py
@@ -1,0 +1,24 @@
+class Html():
+    def Success(): return Html.skeleton('Success', Html.message('SUCCESS', '#4CAF50'))
+    def Error():   return Html.skeleton('Error', Html.message('something went wrong', '#d4695b'))
+
+    def message(text="", text_color='white'):
+        """
+        A div with centered text
+        """
+        html  =  '<div style="display:flex; flex-direction:column; align-items:center; '
+        html += f'justify-content:center; height:100%; width:100%; color:{text_color};">'
+        html += f'<h2>{text}</h2>'
+        html +=  '</div>'
+        return html
+
+    def skeleton(title="", body=""):
+        """
+        basic html structure
+        """
+        html            = '<!DOCTYPE html><html><head><meta charset="utf-8">'
+        if title: html += f'<title>{title}</title>'
+        html           += '<style>html, body { margin:0; padding:0; height:100%; background:black; }</style>'
+        if body: html  += body
+        html           += '</body></html>'
+        return html

--- a/kozubenko/http.py
+++ b/kozubenko/http.py
@@ -1,0 +1,20 @@
+from http.server import SimpleHTTPRequestHandler
+
+
+class Http():
+    def handle_get(handler:SimpleHTTPRequestHandler, html):
+        """
+        QoL utility function for http servers
+
+        Example:  
+        ```python
+        class Server(http.server.SimpleHTTPRequestHandler):
+            def do_GET(self):
+                if url.pathname == '/':        Http.handle_get(self, INDEX_HTML)
+                if url.pathname == '/report':  Http.handle_get(self, REPORT_HTML)
+        """
+        handler.send_response(200)
+        handler.send_header("Content-type", "text/html; charset=utf-8")
+        handler.send_header("Content-Length", str(len(html)))
+        handler.end_headers()
+        handler.wfile.write(html)

--- a/kozubenko/json.py
+++ b/kozubenko/json.py
@@ -1,0 +1,45 @@
+import os, json as JSON
+from typing import Any
+from .os import File
+
+class Json(File):
+    """
+    inherits `File` -> allows you to use `Json()` constructor instead of `os.path.join`. Is a `str`, at it's core.
+
+    **Example**:
+    ```python
+        Json(PROJECT_DIR, jsons, 'data.json').save(Response.json())
+    ```
+    """
+    def load(self):
+        with open(self, 'r', encoding='UTF-8') as file:
+            return JSON.load(file)
+        
+    def save(self, json:Any):
+        """
+        - `json` - usually the result of `requests.get(url).json()`
+        """
+        JSON.dump(json, self.fp(encoding='UTF-8'), indent=2, ensure_ascii=False)
+
+    @staticmethod
+    def Load(path:str, encoding='UTF-8'):
+        """
+        returns data via `json.load(file)`
+        """
+        with open(path, 'r', encoding='UTF-8') as file:
+            return JSON.load(file)
+
+    @staticmethod
+    def Exists(path:str, *paths:str, encoding='UTF-8') -> Any | None:
+        """
+        Utility method for opening files, loading json data in one line.
+
+        **Example:**
+        >>> if(data := Json.exists(SPOTIFY_USER_DATA_DIR, self.name, 'Spotify Account Data', 'Userdata.json')):
+                self.account_creation_time = datetime.strptime(data['creationTime'], "%Y-%m-%d")
+        """
+        file = os.path.join(path, *paths)
+        if(os.path.isfile(file)):
+            return Json.Load(file, encoding)
+        return None
+    

--- a/kozubenko/log.py
+++ b/kozubenko/log.py
@@ -1,0 +1,28 @@
+import re
+from datetime import datetime as dt
+from kozubenko.os import Application_Data_Directory, LogFile
+from definitions import APP_NAME
+
+
+errors = LogFile(Application_Data_Directory(APP_NAME), 'errors', dt.now().strftime('%Y-%m-%d'))
+server = LogFile(Application_Data_Directory(APP_NAME), 'server', dt.now().strftime('%Y-%m-%d'))
+
+class Log():
+    def Error(component:str|None, text:str):
+        message = Log.message(component, text)
+        errors.prepend(message)
+
+    def Server(text:str):
+        message = Log.message('Server', text)
+        server.prepend(message)
+
+    def message(component:str|None, text:str):
+        if component is None: component = 'None'
+        string = f'{dt.now().strftime('%H.%M.%S.%f')}::{component}=>' + '{\n'
+
+        lines = re.split('\r?\n', text)
+        for line in lines:
+            string += f'  {line}\n'
+
+        string += '}\n'
+        return string

--- a/kozubenko/os.py
+++ b/kozubenko/os.py
@@ -1,0 +1,173 @@
+import os, shutil, pathlib, subprocess, pickle
+from typing import Any, Optional, Self
+
+
+type abs_path = str
+
+C_DRIVE = "C:\\"
+def WINDOWS_APPDATA(): return os.getenv("APPDATA")
+
+def Parent(path:str) -> str:
+    return os.path.dirname(path)
+
+def Application_Data_Directory(app_name:str) -> str:
+    """
+    - **Windows:** *`C:/Users/{user}/AppData/Roaming/{ApplicationName}`*  
+    - **Mac/Linux:** *`home/{user}/.{ApplicationName}/`*
+    """
+    if os.name == 'nt': path = os.path.join(os.getenv("APPDATA"), app_name)
+    else:               path = os.path.join(os.path.expanduser("~"), f'.{app_name}')
+    os.makedirs(path, exist_ok=True)
+    return path
+
+def Downloads_Directory() -> str:
+    r"""
+    - **Windows:** returns downloads value under: `Registry:SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders`
+    - **Mac/Linux:** returns `~/Downloads`
+    """
+    if os.name == 'nt':
+        import winreg
+        key = r'SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'
+        downloads_guid = '{374DE290-123F-4565-9164-39C4925E467B}'
+
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, key) as key:
+            Downloads_Directory = winreg.QueryValueEx(key, downloads_guid)[0]
+            return Downloads_Directory
+        
+    elif os.name == 'posix':  # Both Mac and Linux
+        return os.path.join(os.path.expanduser("~"), "Downloads")
+    
+class Path(str):
+    """
+    Allows one to use `Path` constructor instead of `os.path.join`. Is a `str`, at it's core.
+
+    **Example:**
+        >>>  Path(SPOTIFY_USER_DATA_DIR, self.name, 'Spotify Extended Streaming History')
+    """
+    def __new__(cls, path, *paths:str):
+        return super(Path, cls).__new__(cls, os.path.join(path, *(path for path in paths if path is not None)))
+    
+    def exists(self):
+        return os.path.exists(self)
+
+class File(Path):
+    """
+    inherits `Path` -> allows you to use `File()` constructor instead of `os.path.join`. Is a `str`, at it's core.
+    """
+    @property
+    def parent(self) -> Directory:
+        return Directory(pathlib.Path(self).parent)
+    
+    @property
+    def name(self) -> str:
+        return pathlib.Path(self).parts[-1]
+    
+    def fp(self, mode='w', encoding=None): return open(self, mode, encoding=encoding)
+    
+    def contents(self, encoding=None) -> str:
+        with open(self, 'r', encoding=encoding) as file:
+            return file.read()
+        
+    def append(self, string:str, encoding='UTF-8') -> Self:
+        directory = os.path.dirname(self)
+        if not os.path.exists(directory): os.makedirs(directory, exist_ok=True)
+
+        with open(self, 'a', encoding=encoding) as file:
+            file.write(string)
+
+        return self
+
+    def save(self, string:str, encoding='UTF-8') -> Self:
+        directory = os.path.dirname(self)
+        if not os.path.exists(directory): os.makedirs(directory, exist_ok=True)
+
+        with open(self, 'w', encoding=encoding) as file:
+            file.write(string)
+
+        return self
+    
+    def save_binary(self, obj:Any) -> Self:
+        """ Uses pickle, btw """
+        directory = os.path.dirname(self)
+        if not os.path.exists(directory): os.makedirs(directory, exist_ok=True)
+
+        with open(self, 'wb') as file:
+            pickle.dump(obj, file)
+
+        return self
+    
+    def load_binary(self) -> Any:
+        """ Uses pickle, btw """
+        with open(self, 'rb') as file:
+            return pickle.load(file)
+
+    def open(self) -> Self:
+        """ Opens in Notepad++ """
+        NOTEPAD_PP = File(C_DRIVE, 'Program Files', 'Notepad++', 'notepad++.exe')
+        subprocess.Popen([NOTEPAD_PP, self])
+        return self
+
+    def exists(self) -> Self|None:
+        if os.path.isfile(self): return self
+        return None
+    
+    def move(self, destination:str) -> Self:
+        """ Will overwrite file at destination, if exists """
+        if os.path.exists(self):
+            if not os.path.exists(Parent(destination)): os.makedirs(Parent(destination), exist_ok=True)
+            pathlib.Path(self).replace(destination)
+
+    def delete(self) -> Self:
+        if os.path.exists(self): pathlib.Path(self).unlink(self)
+    
+class LogFile(File):
+    def prepend(self, text:str, encoding='UTF-8'):
+        existing_text = ""
+        if self.exists():
+            existing_text = self.contents(encoding=encoding)
+
+        with open(self, 'w', encoding=encoding) as file:
+            file.write(text + existing_text)
+
+class Directory(Path):
+    """
+    inherits `Path` -> allows you to use `Directory()` constructor instead of `os.path.join`. Is a `str`, at it's core.
+    """
+    @property
+    def parent(self) -> Directory:
+        return Directory(pathlib.Path(self).parent)
+    
+    def ensure_parents(self) -> Self:
+        os.makedirs(self.parent, exist_ok=True)
+        return self
+
+    def files(self, filter:Optional[str]=None) -> list[File]:
+        """
+        **Returns:**
+            Files at `path`. Use `filter` to target a substring in filename.
+
+        **Example:**
+        >>>  if files := Directory(EXTENDED_STREAMING_HISTORY).files('Streaming_History_Audio'):
+        """
+        files:list[str] = []
+        for path in os.scandir(self):
+            if path.is_file():
+                if filter and filter in path.path: files.append(File(path.path))
+                else:                              files.append(File(path.path))
+
+        return files
+
+    def parts(self) -> tuple[str, ...]:
+        return pathlib.Path(self).parts
+
+    def exists(self) -> Self|None:
+        if os.path.isdir(self): return self
+        return None
+    
+    def empty(self) -> Self|None:
+        """ i.e: no files in directory """
+        return self if not any(pathlib.Path(self).iterdir()) else None
+
+    def delete(self) -> Self:
+        if os.path.isdir(self): shutil.rmtree(self)
+        return self

--- a/kozubenko/print.py
+++ b/kozubenko/print.py
@@ -1,0 +1,226 @@
+from os import PathLike
+import sys, enum
+from typing import Callable, Literal, Union
+
+
+FileDescriptorOrPath = Union[int, str, bytes, PathLike[str], PathLike[bytes]]
+WritableTextMode = Literal[
+    'w',    # write
+    'a',    # append
+    'x',    # exclusive create
+    'w+',   # write/read
+    'a+',   # append/read
+    'x+',   # exclusive create/read
+    'wt',   # write (text mode)
+    'at',   # append (text mode)
+    'xt',   # exclusive create (text mode)
+    'wt+',  # write/read (text)
+    'at+',  # append/read (text)
+    'xt+'   # exclusive create/read (text)
+]
+def redirect_print_to_file(file:FileDescriptorOrPath, mode:WritableTextMode, print_function:Callable):
+    """
+    Example Use: `redirect_print_to_file(report, 'w', lambda: print_list(problem_chapters))`
+    """
+    with open(file, mode, encoding="UTF-8") as file:
+        old_stdout = sys.stdout
+        sys.stdout = file
+        try:
+            print_function()
+        finally:
+            sys.stdout = old_stdout
+
+def print_dict(_dict:dict):
+    """
+    Recommended for more complex dicts (but uses repr instead):
+     `import pprint`
+     `pprint.pprint(_dict)`
+    """
+    for key, value in _dict.items():
+        print(f'{key}: {value}\n')
+
+
+class ANSI(enum.StrEnum):
+    GREEN       = "\033[92m"
+    YELLOW      = "\033[93m"
+    RED         = "\033[91m"
+    CYAN        = "\033[96m"
+    WHITE       = "\033[97m"
+    GRAY        = "\033[37m"
+    BLUE        = "\033[36m"
+    DARK_RED    = "\033[31m"
+    DARK_GRAY   = "\033[90m"
+    DARK_GREEN  = "\033[32m"
+    DARK_YELLOW = "\033[33m"
+    RESET       = "\033[0m"
+
+    # 24-bit (TrueColor)
+    ROSE_GOLD   = "\033[38;2;255;196;201m"
+    LITE_RED   = "\033[38;2;232;107;118m"
+    LITE_GREEN = "\033[38;2;96;223;107m"
+
+def colored_input(string:str, color:ANSI=ANSI.YELLOW):
+    input(f'{color}{string}{ANSI.RESET}')
+
+
+class Print:
+    def list(list:list, color:ANSI=None, flip=False):
+        """
+        `flip` - i.e: `descending`/`ascending` order
+        """
+        if(flip):
+            list = reversed(list)
+
+        for item in list:
+            if(sys.stdout.isatty()):
+                print(f'{color}{item}{ANSI.RESET}\n') if color else print(f'{item}\n')
+            else:
+                print(f'{item}\n')
+
+    def green(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.GREEN}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+            
+    def yellow(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.YELLOW}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def red(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.RED}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def rose_gold(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.ROSE_GOLD}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def lite_red(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.LITE_RED}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def lite_green(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.LITE_GREEN}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def cyan(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.CYAN}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def white(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.WHITE}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def gray(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.GRAY}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def blue(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.BLUE}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def dark_red(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.DARK_RED}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def dark_gray(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.DARK_GRAY}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def dark_green(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.DARK_GREEN}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+    def dark_yellow(text:str, new_line=True):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.DARK_YELLOW}{text}{ANSI.RESET}", end='\n' if new_line else "")
+        else:
+            print(text, end='\n' if new_line else "")
+
+class Write:
+    """
+    The no-new-line-at-end version of Print
+    """
+    def lite_red(text:str):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.LITE_RED}{text}{ANSI.RESET}", end="")
+        else:
+            print(text, end="")
+
+    def lite_green(text:str):
+        """
+        ANSI codes are stripped if `sys.stdout` is not a `terminal`.
+        """
+        if sys.stdout.isatty():
+            print(f"{ANSI.LITE_GREEN}{text}{ANSI.RESET}", end="")
+        else:
+            print(text, end="")

--- a/kozubenko/random.py
+++ b/kozubenko/random.py
@@ -1,0 +1,9 @@
+import string, random
+
+
+class Random():
+    def string(len:int, of=string.ascii_letters+string.digits) -> str:
+        """
+        returns a randomized string
+        """
+        return ''.join(random.choices(of, k=len))

--- a/kozubenko/string.py
+++ b/kozubenko/string.py
@@ -1,0 +1,23 @@
+
+
+def whitespace(amount:int) -> str:
+    return " " * amount
+
+
+class Str(str):
+
+    def pad(self, amount:str, indent_size=2) -> str:
+        string = ""
+        for line in self.splitlines(keepends=True):
+            string += whitespace(amount * indent_size) + line
+
+        return string
+
+    @staticmethod
+    def From(items:list, separator="\n\n") -> str:
+        """ Transforms list into a pretty string. """
+        string = ""
+        for item in items:
+            string += f'{item}{separator}'
+
+        return string[:-1]

--- a/kozubenko/url.py
+++ b/kozubenko/url.py
@@ -1,0 +1,26 @@
+import urllib
+
+
+class Url():
+    """
+    QoL for http servers
+
+    Example:  
+    ```python
+    class Server(http.server.SimpleHTTPRequestHandler):
+        def do_GET(self):
+            url = Url(self.path)
+            pathname = url.pathname
+            param1 = url.params.get('param1', [None])[0]
+            param2 = url.params.get('param2', [None])[0]
+    """
+    def __init__(self, path):
+        self.parsed = urllib.parse.urlparse(path)
+        self.pathname = self.parsed.path
+        self.params = urllib.parse.parse_qs(self.parsed.query)
+
+    def pathname(self) -> str:
+        """
+        `http://127.0.0.1:8080/callback?code=AQDYLH` would return `/callback`
+        """
+        return self.pathname

--- a/kozubenko/utils.py
+++ b/kozubenko/utils.py
@@ -1,0 +1,33 @@
+
+class Utils:
+    
+    def list_to_str(_list:list[str], char_separator = " "):
+        """
+        `list_to_str(['a', 'b', 'c'], ';') -> "a;b;c"`
+        """
+        return char_separator.join(_list)
+    
+
+def assert_list(var_name:str, _list:list, min_len:int=None, max_len:int=None, returnBool=False):
+    """
+    Use to enforce type annotations. Raises Exception, unless `returnBool=True`:
+    * if _list is not a list
+    * len(_list) < min_len (*optional*)
+    * len(_list) > max_len (*optional*)
+    * returnBool (*optional*)
+    """
+    if not returnBool:    
+        if not isinstance(_list, list):
+            raise Exception(f"assert_list({var_name}): must be a list, not: {type(_list)}")
+        if(min_len) and len(_list) < min_len:
+            raise Exception(f"assert_list({var_name}): length of list under min_len: {min_len}")
+        if(max_len) and len(_list) > max_len:
+            raise Exception(f"assert_list({var_name}): length of list exceeds max_len: {max_len}")
+    else:
+        if not isinstance(_list, list):
+            return False
+        if min_len is not None and len(_list) < min_len:
+            return False
+        if max_len is not None and len(_list) > max_len:
+            return False
+        return True

--- a/main.py
+++ b/main.py
@@ -1,0 +1,31 @@
+from kozubenko.os import Downloads_Directory, File
+from kozubenko.print import Print
+from kozubenko.string import Str
+from spotify_py.spotify_requests import SimpleRequests, SaveToPlaylistRequest
+from spotify_py.SpotifyUser import SpotifyUser, I_want_her_favorite_songs
+from import_Spotify_Data import Import_Spotify_Data
+
+
+
+"""
+"I want my Wife's true favorite songs, based on Her entire Spotify listening history, minus my Liked Songs"
+    Assumes: you have already imported the necessary Spotify Data Types; ie:
+        - `Spotify Account Data` for `ME`,                via: `py ./import_spotify_data.py Stan`
+        - `Spotify Extended Streaming History` for `HER`, via: `py ./import_spotify_data.py Luna`
+"""
+ME = SpotifyUser('Stan')
+HER = SpotifyUser('Luna')
+
+her_favorite_songs = I_want_her_favorite_songs(ME, HER, minimum_listen_time_in_hours = 1)
+File(Downloads_Directory(), "her_favorite_songs.txt").save(Str.From(her_favorite_songs))
+
+
+"""
+"I want a Spotify playlist created from Her favorite 1000 songs" 
+    Assumes: you've created an app on: https://developer.spotify.com/dashboard,
+             client_id, client_secret set in file ./.env
+"""
+SaveToPlaylistRequest.New_Playlist(
+    playlist_name='Her Favorite Songs',
+    description='upper segment of her lifetime_listening_record (1hr) - songs_I_already_liked'
+).Handle(her_favorite_songs).Result()

--- a/spotify_py/IHandleRequest.py
+++ b/spotify_py/IHandleRequest.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from typing import Self
+
+
+class Success(str): pass
+class Partial(str): pass
+class Failure(str): pass
+
+class IHandleRequest(ABC):
+    def __init__(self):
+        self.result: Success|Partial|Failure = None
+        self.error: str = None
+
+    @abstractmethod
+    def Handle() -> Self:
+        pass
+
+    @abstractmethod
+    def Result(self, print=True) -> Success|Partial|Failure:
+        pass

--- a/spotify_py/SpotifyUser.py
+++ b/spotify_py/SpotifyUser.py
@@ -1,0 +1,141 @@
+"""
+`SpotifyUser` deals with three types of user data:
+    1. Spotify Account Data
+    2. Spotify Extended Streaming History
+    3. Spotify Technical Log Information
+
+Request Data from Spotify: https://www.spotify.com/us/account/privacy/
+    Data Details: https://support.spotify.com/us/article/understanding-your-data/
+"""
+import os
+from datetime import datetime
+from typing import Optional
+from Spotify_Data_Types import Spotify_Data_Type
+from kozubenko.os import Directory, File
+from kozubenko.json import Json
+from kozubenko.print import Print
+from kozubenko.string import Str
+from .spotify_requests import SimpleRequests
+from .extended_streaming_history import AudioStreamingHistory, ExtendedStreamingHistory
+from .account_data import AccountData, DuplicateSong
+from .models.ISong import ISong
+from .models.IStreamed import StreamedSong
+from definitions import SPOTIFY_USER_DATA_DIR
+
+
+def USER_DATA_DIR(name:str, data_type:Optional[Spotify_Data_Type]=None) -> Directory:
+    """
+    - `data_type` - if passed not a `Spotify_Data_Type`, will throw!
+    """
+    if data_type and data_type not in Spotify_Data_Type:
+        raise Exception('USER_DATA_DIR(): data_type is not a Spotify_Data_Type!')
+
+    return Directory(SPOTIFY_USER_DATA_DIR, name, data_type)
+
+def ACCOUNT_DATA(name:str):               return USER_DATA_DIR(name, Spotify_Data_Type.ACCOUNT_DATA)
+def EXTENDED_STREAMING_HISTORY(name:str): return USER_DATA_DIR(name, Spotify_Data_Type.EXTENDED_STREAMING_HISTORY)
+
+type occurrences = int
+
+class SpotifyUser:
+    """
+    Use `py ./import_Spotify_Data.py {name}` to import `my_spotify_data.zip`. Data types Spotify offers:
+    1. Spotify Account Data
+    2. Spotify Extended Streaming History
+    3. Spotify Technical Log Information
+
+    ***Instantiate `SpotifyUser` with same `name` to manipulate/transform above data [1-2] to find statistical insights.***
+    """
+    @property
+    def liked_songs(self) -> list[ISong]: return self._songs_liked
+
+    def __init__(self, name:str):
+        self.name = name
+
+        self._account_creation_time:datetime = None
+        if(data := Json.Exists(ACCOUNT_DATA(name), 'Userdata.json')):
+            self._account_creation_time = datetime.strptime(data['creationTime'], "%Y-%m-%d")
+
+        self._songs_liked:set[ISong]; self._song_duplicates:list[DuplicateSong]
+        if(data := Json.Exists(ACCOUNT_DATA(name), 'YourLibrary.json')):
+            self._songs_liked, self._song_duplicates = AccountData.YourLibrary(data)
+
+        self._history:AudioStreamingHistory = ExtendedStreamingHistory.Audio(
+            name,
+            EXTENDED_STREAMING_HISTORY(name).files(filter='Streaming_History_Audio')
+        )
+
+    def song_streaming_history(self, minimum_listen_time_in_minutes = 30) -> list[StreamedSong]:
+        """ Required: `Spotify Extended Streaming History`  """
+        return [song for song in self._history.songs if (song.total_ms_played > minimum_listen_time_in_minutes*60*1000)]
+    
+    def favorite_songs(self, minimum_listen_time_in_hours = 3) -> list[StreamedSong]:
+        """ Required: `Spotify Extended Streaming History`  """
+        return [song for song in self.song_streaming_history(minimum_listen_time_in_hours*60)]
+
+    def lost_song_candidates(self, minimum_listen_time_in_minutes = 20) -> list[StreamedSong]:
+        """
+        technically: `self.song_streaming_history(minimum_listen_time_in_minutes=20)` NOT IN `self.liked_songs`
+
+        **Required:**
+            - `Spotify Extended Streaming History`
+            - `Spotify Account Data`
+        """
+        return [song for song in self.song_streaming_history(minimum_listen_time_in_minutes) if song not in self._songs_liked]
+
+    
+    @staticmethod
+    def Save_Liked_Songs(name:str) -> dict[ISong, occurrences]:
+        """
+        Uses Spotify WebApi instead. Saves as binary file in: `USER_DATA_DIR(name)`.
+
+        Eventually, one could swap out:  
+            - `SpotifyUser().liked_songs` WITH:
+            - `SpotifyUser.Liked_Songs()
+        when requirements for one or the other can't be met.
+
+        **PARAMETERS:**
+            - `name` - Same `name` you use to init: `SpotifyUser(name)`
+        """
+        liked_songs = SimpleRequests.Liked_Songs()
+
+        file = File(USER_DATA_DIR(name), 'liked_songs').save_binary(liked_songs)
+        Print.green(f'SpotifyUser.Save_Liked_Songs(): saved {len(liked_songs)} songs: {file}')
+        
+        return liked_songs
+
+
+def I_want_her_favorite_songs(me:SpotifyUser, her:SpotifyUser, minimum_listen_time_in_hours = 3) -> list[StreamedSong]:
+    """
+    technically: `her.song_streaming_history`, subtracted by `me.songs_liked`, filtered by `minimum_listen_time_in_hours`.
+        
+    **Required:**
+        - `Spotify Account Data` FOR `me`
+        - `Spotify Extended Streaming History` FOR `her` 
+    """
+    return [song for song in her.song_streaming_history(minimum_listen_time_in_hours*60) if song not in me._songs_liked]
+
+def have_I_lost_a_song_from_Liked(name:str) -> list[ISong]:
+    """
+    - `name` - Same `name` you use to init: `SpotifyUser(name)`
+
+    Will check against your last backup. To do an actual backup, use: `SpotifyUser.Save_Liked_Songs()`
+    """
+    actual_Liked = SimpleRequests.Liked_Songs()
+    backup_Liked:dict[ISong, occurrences] = File(USER_DATA_DIR(name), 'liked_songs').load_binary()
+
+    missing:list[ISong] = []
+    for song in backup_Liked.keys():
+        if song not in actual_Liked.keys():
+            missing.append(song)
+
+    if len(missing) < 1:
+        Print.green(f'No, {name}: you have NOT lost any songs :)') 
+    else:
+        Print.red(f'Yes, {name}: you have lost {len(missing)} songs...\n')
+        for song in missing:
+            Print.lite_red(Str(str(song)).pad(1))
+        if len(missing) > 10:
+            Print.red(f'\nYes, {name}: you have lost {len(missing)} songs...')
+
+    return missing

--- a/spotify_py/account_data.py
+++ b/spotify_py/account_data.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+from typing import Any
+from .models.ISong import ISong
+
+
+@dataclass
+class DuplicateSong:
+    song: ISong
+    total_duplicates: int = 1
+
+    def console_report(self):
+        return f'{str(self.song)} -> {self.total_duplicates}'
+
+
+type songs_liked = set[ISong]
+type song_duplicates = list[DuplicateSong]
+
+class AccountData:
+    """
+    **Requires:** `/Spotify User Data/{name}/Spotify Account Data`.  
+    
+    ***See: `SpotifyUser.py` for import steps.***
+    """
+
+    @staticmethod
+    def YourLibrary(data:Any) -> tuple[songs_liked, song_duplicates]:
+        """
+        **Requires:** `/Spotify User Data/{name}/Spotify Account Data/YourLibrary.json`  
+            - `data` - pass in above file with: `json.load(file)`
+
+        Note: `YourLibrary.json` does not preserve order by time added! If required, use WebApi:
+            - https://developer.spotify.com/documentation/web-api/reference/get-users-saved-tracks
+
+        **Theoretical Breakage Point:**
+            - 1,171 liked songs generated ~7067 lined `YourLibrary.json`
+            - 387,000 lines lowest limit for `Streaming_History_Audio_***.json`
+            - `AccountData.LikedSongs()` theoretical upper limit: `SpotifyUser.liked.count > 63,234`
+        """
+        liked:       set[ISong]                   = set()
+        duplicates:  dict[ISong, DuplicateSong]   = {}
+
+        for record in data['tracks']:
+            song = ISong(record['track'], record['artist'], record['album'])
+
+            if(song in liked):
+                duplicate = duplicates.pop(song, DuplicateSong(song))
+                duplicate.total_duplicates += 1
+                duplicates[duplicate.song] = duplicate
+            else:
+                liked.add(song)
+
+        return (liked, duplicates.values())

--- a/spotify_py/extended_streaming_history.py
+++ b/spotify_py/extended_streaming_history.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+from kozubenko.print import Print
+from kozubenko.json import Json
+from .models.IStreamed import *
+
+
+@dataclass
+class AudioStreamingHistory:
+    """
+    Analyzes lifetime listening record to find `songs`/`podcasts`/`audiobooks`, sorted by `total_ms_played`. Implementation details: `IStreamed.py`.
+    
+    **Requires:**
+        - `ExtendedStreamingHistory` directory has at least one file: `/Streaming_History_Audio_***.json`
+            - e.g: `/Spotify User Data/{name}/Spotify Extended Streaming History/Streaming_History_Audio_2021_3.json`
+    """
+    songs:    list[StreamedSong]
+    podcasts:  list[Podcast]
+    audiobooks: list[AudioBook]
+
+    total_records: int
+    unexpected_records: list[Unidentified]
+
+    name: str
+
+    def console_report(self):
+        Print.green(f'{self.name}.history => iterated through {self.total_records} records. Unidentified: {len(self.unexpected_records)}')
+        Print.green(f'   Songs      : {self.songs.__len__()}')
+        Print.green(f'   Podcasts   : {self.podcasts.__len__()}')
+        Print.green(f'   AudioBooks : {self.audiobooks.__len__()}')
+
+
+class ExtendedStreamingHistory:
+    """
+    **Requires:** `/Spotify User Data/{name}/Spotify Extended Streaming History`   
+    
+    ***See: `SpotifyUser.py` for import steps.***
+    """
+
+    @staticmethod
+    def Audio(name:str, json_files:list[str]) -> AudioStreamingHistory:
+        """
+        Pass in List of jsons with *`"Streaming_History_Audio"`* in their filename.  
+        
+        e.g: `Streaming_History_Audio_2018_1.json`
+        """
+        songs_streamed:      dict[str, StreamedSong] = {}
+        podcasts_streamed:   dict[str, Podcast]      = {}
+        audiobooks_streamed: dict[str, AudioBook]    = {}
+        
+        iterations = 0
+        unexpected: list[Unidentified] = []
+
+        for json in json_files:
+            for record in Json.Load(json):
+                iterations += 1
+                audio = IStreamed.From(record)
+                representation = repr(audio)
+
+                if isinstance(audio, StreamedSong):
+                    fromDict = songs_streamed.pop(representation, None)
+                    if fromDict is not None:
+                        audio.combine(fromDict)
+                    songs_streamed[representation] = audio
+
+                elif isinstance(audio, Podcast):
+                    fromDict = podcasts_streamed.pop(representation, None)
+                    if fromDict is not None:
+                        audio = audio.combine(fromDict)
+                    podcasts_streamed[representation] = audio
+
+                elif isinstance(audio, AudioBook):
+                    fromDict = audiobooks_streamed.pop(representation, None)
+                    if fromDict is not None:
+                        audio = audio.combine(fromDict)
+                    audiobooks_streamed[representation] = audio
+
+                elif isinstance(audio, Unidentified):
+                    audio.file = json
+                    audio.read_cycle = iterations
+                    unexpected.append(audio)
+
+        return AudioStreamingHistory(
+            sorted(songs_streamed.values(), reverse=True), sorted(podcasts_streamed.values(), reverse=True), sorted(audiobooks_streamed.values(), reverse=True),
+            iterations,
+            unexpected,
+            name
+        )

--- a/spotify_py/models/ISong.py
+++ b/spotify_py/models/ISong.py
@@ -1,0 +1,29 @@
+"""
+Spotify Extended Streaming History
+    "master_metadata_album_artist_name" -> tracks only one artist, evidently: artists[0] from: https://api.spotify.com/v1/tracks/{id}
+"""
+from dataclasses import dataclass
+
+
+@dataclass
+class ISong:
+    """
+    **Attributes:**
+        - `artist` - e.g: `San Holo`
+            - Extended Streaming History, tracks only one artist, evidently `artists[0]` from: https://api.spotify.com/v1/tracks/{id}
+            e.g: `"master_metadata_album_artist_name": "San Holo"`
+    """
+    title: str
+    artist: str
+    album: str
+
+    def __eq__(self, other):
+        if not isinstance(self, ISong):
+            return False
+        return (self.title == other.title and self.artist == self.artist and self.album == other.album)
+    
+    def __hash__(self):
+        return hash((self.title, self.artist, self.album))
+    
+    def __str__(self):
+        return f'{self.title}:{self.artist}'

--- a/spotify_py/models/IStreamed.py
+++ b/spotify_py/models/IStreamed.py
@@ -1,0 +1,149 @@
+"""
+Associated to: Spotify Extended Streaming History
+"""
+from dataclasses import dataclass
+from typing import Any
+from spotify_py.models.ISong import ISong
+
+
+@dataclass
+class Unidentified:
+    """
+    A Json record in a `Streaming_History_Audio_***.json` with an unexpected shape.
+    """
+    record:str             # the json record as a str
+    file:str       = None  # absolute path of file where this record was found
+    read_cycle:int = None  # aka: parser iterations
+
+
+@dataclass
+class IStreamed:
+    """
+    A single record in a `Streaming_History_Audio_***.json`  
+
+    `IStreamed` objects can be combined to form totals over a time domain.
+    """
+    amount_played   = 1     # amount of records
+    amount_listened = 0     # amount of finished listens
+    total_ms_played: int    # sum of ms_played from each record 
+    ts: list[str]           # list of timestamps of each listen
+    uri: str
+
+    @staticmethod
+    def From(record:Any):
+        if record['master_metadata_track_name'] : return StreamedSong(record)
+        if record['episode_name']               : return Podcast(record)
+        if record['audiobook_title']            : return AudioBook(record)
+        else                                    : return Unidentified(record)
+
+    def combine(self, other):
+        if isinstance(other, IStreamed):
+            self.amount_played = (self.amount_played + other.amount_played)
+            self.amount_listened = (self.amount_listened + other.amount_listened)
+            self.total_ms_played = (self.total_ms_played + other.total_ms_played)
+            self.ts.extend(other.ts)
+
+        return self
+    
+    def __lt__(self, other):
+        """
+        This supports: `sorted(songs_streamed.values())`
+        """
+        if not isinstance(other, IStreamed):
+            raise TypeError('__lt__ only possible between classes that implement IStreamed')
+        return self.total_ms_played < other.total_ms_played
+        
+    def __str__(self):
+        # string = f'{self.uri}\n'
+        string = f'{self.amount_listened}:{self.amount_played};  '
+
+        if self.total_ms_played < 1000:
+            string += f'{self.total_ms_played}ms'
+            return string
+        
+        seconds = self.total_ms_played/1000; minutes = seconds/60; hours = minutes/60
+        translatedTimeString = f'{seconds:.0f}s'
+        if minutes > 1:
+            translatedTimeString += f' => {minutes:.2f}m'
+        if hours > 1:
+            translatedTimeString += f' => {hours:.2f}hrs'
+
+        return string + translatedTimeString
+
+@dataclass
+class StreamedSong(IStreamed, ISong):
+    """
+    Possible shape of a record in `Streaming_History_Audio_***.json`.
+
+    `spotify_track_uri` will not be null. example form: `spotify:track:4GnkzqMpGmJIGt8geJetwF`
+    """
+    def __init__(self, record):
+        ISong.__init__(self, title=record['master_metadata_track_name'], artist=record['master_metadata_album_artist_name'], album=record['master_metadata_album_album_name'])
+        IStreamed.__init__(self, total_ms_played=record['ms_played'], ts=[record['ts']], uri=record['spotify_track_uri'])
+        if record.get('reason_end') == 'trackdone':
+            self.amount_listened = 1
+
+    def __eq__(self, other):
+        return ISong.__eq__(self, other)
+    
+    def __hash__(self):
+        """
+        works alongside `__eq__` to make list comprehensions possible.  
+        e.g: this `__hash__()` makes this part work `if song not in self._songs_liked` in `lost_song_candidates()`
+        """
+        return ISong.__hash__(self)
+
+    def __repr__(self):
+        return f'StreamedSong:{self.title}:{self.artist}'
+       
+    def __str__(self):
+        string = f'{ISong.__str__(self)}\n'
+        string += f'{IStreamed.__str__(self)}\n'
+        string += f'{self.uri}'
+        return string
+
+@dataclass
+class Podcast(IStreamed):
+    name: str
+    show_name:str
+
+    def __init__(self, record):
+        self.name      = record['episode_name']
+        self.show_name = record['episode_show_name']
+
+        IStreamed.__init__(self, total_ms_played=record['ms_played'], ts=[record['ts']], uri=record['spotify_episode_uri'])
+        if record.get('reason_end') == 'trackdone':
+            self.amount_listened = 1
+            
+    def __eq__(self, other):
+        if not isinstance(other, Podcast):
+            return False
+        return (self.name == other.name and self.show_name == other.show_name)
+    
+    def __repr__(self):
+        return f'Podcast:{self.name}:{self.show_name}'
+    
+    def __str__(self):
+        string = f'{self.name} - {self.show_name}\n'
+        string += IStreamed.__str__(self)
+        return string
+
+@dataclass
+class AudioBook(IStreamed):
+    audiobook_title: str
+    audiobook_chapter_title: str
+    audiobook_uri: str
+    audiobook_chapter_uri: str
+
+    def __init__(self, record):
+        IStreamed.__init__(self, total_ms_played=record['ms_played'], ts=record['ts'], uri=record['audiobook_uri'])
+        if record.get('reason_end') == 'trackdone':
+            self.amount_listened = 1
+
+        self.audiobook_title = record['audiobook_title']
+        self.audiobook_chapter_title = record['audiobook_chapter_title']
+        self.audiobook_uri = record['audiobook_uri']
+        self.audiobook_chapter_uri = record['audiobook_chapter_uri']
+
+    def __repr__(self):
+        return f'AudioBook:{self.audiobook_title}'

--- a/spotify_py/models/Track.py
+++ b/spotify_py/models/Track.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from spotify_py.models.ISong import ISong
+
+
+@dataclass
+class Track(ISong):
+    """
+    https://api.spotify.com/v1/tracks/{id}
+
+    **Attributes:**
+        - `id` - e.g: `7snnEDYwv30hRtmifVni8P`
+            - Extended Streaming History, instead uses: `"spotify_track_uri": "spotify:track:7snnEDYwv30hRtmifVni8P"`
+        - `added_at` - UTC timestamp, format: ISO-8601, e.g: `2026-02-11T07:57:54Z`
+    """
+    id:str
+    added_at:str

--- a/spotify_py/spotify_auth.py
+++ b/spotify_py/spotify_auth.py
@@ -1,0 +1,172 @@
+"""
+    To interact with the Spotify Web Api, you need to login into Spotify and get an
+            access_token, i.e: Bearer Token
+
+    The hope was that you did not need to delve into the specifics here...
+        call: SpotifyAuth.Validate_Access_Token()
+
+    Prerequisistes, look at: `Enable Spotify Web Api Interactions` section at:
+        https://github.com/staspk/SpotifyAPI
+    
+"""
+import base64, urllib, requests, socketserver, http.server, threading
+from datetime import datetime, timedelta
+from kozubenko.print import ANSI, Print, Write
+from kozubenko.html import Html
+from kozubenko.http import Http
+from kozubenko.url import Url
+from kozubenko.OAuth2 import OAuth2
+from kozubenko.env import Env
+from definitions import REDIRECT_URI, PERMISSION_SCOPES
+
+
+class SpotifyAuth(threading.Thread):
+    """
+    Using the `Spotify Web API` (creating playlists, etc.) requires an
+        `access_token`, i.e: Bearer Token
+
+    The only "public" method: `SpotifyAuth.Validate_Access_Token()`
+    """
+    redirect_uri = REDIRECT_URI
+    scopes_needed = PERMISSION_SCOPES
+
+    IP, PORT = "127.0.0.1", 8080
+    Instance = None
+
+    auth_code_flow_started, auth_code_flow_complete = False, False
+
+    def Validate_Access_Token(reject=False):
+        """
+        The `access_token` will be saved to the .env file. `spotify_requests.py` later pulls from there. 
+
+        On first call, procures an `access_token` via `authorization_code_flow()`
+            - must login into Spotify/grant permissions through a console generated link
+            - Required: `client_id`, `client_secret` key/value pairs in `.env`. Get them at: https://developer.spotify.com/dashboard
+
+        OR refreshes an existing token via a POST call (tokens have a 1hr lifespan)
+
+        **PARAMETERS:**
+            `reject` - set True, if brand new `access_token` is desired, no matter what
+        """
+        if not Env.loaded: Env.Load()
+        access_token = Env.Vars.get('access_token', None)
+        refresh_token = Env.Vars.get('refresh_token', None)
+        token_expiration_str = Env.Vars.get('token_expiration', None)
+
+        if not (access_token and refresh_token and token_expiration_str) or reject is True:
+            SpotifyAuth.authorization_code_flow(); return
+        
+        expiration = datetime.strptime(token_expiration_str, '%Y-%m-%d %H:%M:%S') - timedelta(minutes=5)
+        if datetime.now() > expiration:
+            if not SpotifyAuth.refresh_token():
+                SpotifyAuth.authorization_code_flow()
+
+    def __init__(self, IP=IP, PORT=PORT):
+        if(IP): SpotifyAuth.IP = IP
+        if(PORT): SpotifyAuth.PORT = PORT
+        threading.Thread.__init__(self, name='SpotifyAuth_thread', daemon=True)
+        SpotifyAuth.Instance = self
+
+    def stop(message=False):
+        if SpotifyAuth.Instance is not None:
+            SpotifyAuth.Instance.http_daemon.shutdown()
+            SpotifyAuth.Instance = None
+
+    def run(self):
+        """ `threading.Thread` override, is the unit of work """
+        with socketserver.TCPServer((SpotifyAuth.IP, SpotifyAuth.PORT), Server) as http_daemon:
+            self.http_daemon = http_daemon
+            http_daemon.serve_forever(poll_interval=.5)
+
+    def refresh_token() -> bool:
+        Env.Load()
+        refresh_token = Env.Vars.get('refresh_token', None)
+
+        url = 'https://accounts.spotify.com/api/token'
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Authorization': 'Basic ' + base64.b64encode(f'{Env.Vars['client_id']}:{Env.Vars['client_secret']}'.encode()).decode('utf-8')
+        }
+        body = {
+            'grant_type': 'refresh_token',
+            'refresh_token': refresh_token
+        }
+
+        response = requests.post(url, headers=headers, data=body)
+        if response.status_code == 200:
+            data = response.json()
+            expiration = datetime.now() + timedelta(seconds=int(data['expires_in']))
+
+            Env.Save('access_token', data['access_token'])
+            Env.Save('token_expiration', expiration.strftime('%Y-%m-%d %H:%M:%S'))
+            if 'refresh_token' in data: Env.Save('refresh_token', data['refresh_token'])
+            return True
+        else:
+            Print.dark_red(f'SpotifyAuth.refresh_token(): POST error, status_code: {response.status_code}')
+            return False
+
+    def authorization_code_flow():
+        """
+        Generates link that starts the `access_token` procurement process, and waits for user. Actual process handled by `Server`.
+        """
+        SpotifyAuth().start()
+        endpoint = 'https://accounts.spotify.com/authorize?' + urllib.parse.urlencode({
+            'response_type': 'code',
+            'client_id': Env.Vars['client_id'],
+            'scope': SpotifyAuth.scopes_needed,
+            'redirect_uri': SpotifyAuth.redirect_uri,
+            'state': OAuth2.generate_state(),
+            'show_dialog': True
+        })
+
+        SpotifyAuth.auth_code_flow_started = True
+
+        Write.lite_red('\nNeed Permissions Grant through Spotify.'); Write.lite_green(' Please Login '); Print.lite_red('using this link:')
+        Print.dark_gray(f'  {endpoint}')
+        input(f'{ANSI.LITE_RED.value}\n  When redirected to success page, {ANSI.LITE_GREEN.value}Press Enter {ANSI.LITE_RED.value}to continue...\033[0m')
+
+        if(SpotifyAuth.auth_code_flow_started and SpotifyAuth.auth_code_flow_complete):
+            Print.green('\n  SpotifyAuth.authorization_code_flow(): Access Token Granted!\n')
+        else: Print.dark_red('\n  SpotifyAuth.authorization_code_flow(): Process Not Complete! Expect Errors attempting to use the Spotify Web Api.\n')
+        
+        threading.Thread(target=SpotifyAuth.stop, daemon=True).start()
+        
+class Server(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        url = Url(self.path)
+        if url.pathname == '/callback':
+            code  = url.params.get('code', [None])[0]
+            state = url.params.get('state', [None])[0]  # in the future can be used to protect against cross-site request forgery
+
+            if not (code and state):
+                Http.handle_get(self, Html.Error().encode()); return
+
+            url = 'https://accounts.spotify.com/api/token'
+            headers = {
+                'content-type': 'application/x-www-form-urlencoded',
+                'Authorization': 'Basic ' + base64.b64encode(f'{Env.Vars.get('client_id', None)}:{Env.Vars.get('client_secret', None)}'.encode()).decode('utf-8')
+            }
+            data = {
+                'code': code,
+                'redirect_uri': SpotifyAuth.redirect_uri,
+                'grant_type': 'authorization_code'
+            }
+
+            response = requests.post(url, headers=headers, data=data, json=True)
+            if response.status_code == 200:
+                SpotifyAuth.auth_code_flow_complete = True
+                data = response.json()
+                expiration = datetime.now() + timedelta(seconds=int(data['expires_in']))
+                Env.Save({
+                    'access_token': data['access_token'],
+                    'refresh_token': data['refresh_token'],
+                    'token_expiration': expiration.strftime('%Y-%m-%d %H:%M:%S')
+                })
+                Http.handle_get(self, Html.Success().encode())
+            else:
+                Http.handle_get(self, Html.Error().encode())
+        else: self.send_error(404, 'does not exist')
+    
+    def log_message(self, format, *args):
+        """ `SimpleHTTPRequestHandler` override to silence console output """
+        pass

--- a/spotify_py/spotify_requests.py
+++ b/spotify_py/spotify_requests.py
@@ -1,0 +1,283 @@
+"""
+https://developer.spotify.com/documentation/web-api
+"""
+import time, requests, pickle
+from typing import Optional, Self
+from definitions import PROJECT_ROOT_DIRECTORY, TEMP_DIR
+from kozubenko.env import Env
+from kozubenko.log import Log
+from kozubenko.print import Print
+from kozubenko.utils import assert_list
+from spotify_py import IHandleRequest
+from spotify_py.models.Track import Track
+from spotify_py.spotify_auth import SpotifyAuth
+from .models.ISong import ISong
+from .IHandleRequest import *
+
+
+class UserID(str):
+    ENV_KEY = "user_id"
+    _user_id:UserID = None
+
+    @staticmethod
+    def Get() -> UserID:
+        if UserID._user_id is None:
+            if not Env.loaded: Env.Load()
+
+            user_id = Env.Vars.get(UserID.ENV_KEY, None)
+            if user_id is None:
+                user_id = SimpleRequests.get_UserID()   # throws, on failure to get user_id 
+
+            UserID._user_id = UserID(user_id)
+
+        return UserID._user_id
+
+class PlaylistID(str): pass
+class PlaylistName(str): pass
+
+
+class SimpleRequests:
+    def get_UserID() -> UserID|None:
+        """ https://developer.spotify.com/documentation/web-api/reference/get-current-users-profile
+        """
+        ENDPOINT = 'https://api.spotify.com/v1/me'
+
+        SpotifyAuth.Validate_Access_Token()
+        response = requests.get(url=ENDPOINT, headers={
+            'Authorization': f'Bearer {Env.Vars['access_token']}'
+        })
+
+        if response.status_code == 200:
+            user_id = UserID(response.json().get('id'))
+            UserID._user_id = user_id
+            return user_id
+        else:
+            Log.Error(SimpleRequests, (
+                f'response.status_code: {response.status_code}\n'
+                f'error message: {response.json().get('error').get('message')}'
+            ))
+
+    def get_PlaylistName(playlist_id:str) -> PlaylistName|None:
+        """ https://developer.spotify.com/documentation/web-api/reference/get-playlist
+        """
+        SpotifyAuth.Validate_Access_Token()
+        response = requests.get(f'https://api.spotify.com/v1/playlists/{playlist_id}', headers={
+            'Authorization': f'Bearer {Env.Vars['access_token']}'
+        })
+        if response.status_code == 200:
+            return response.json().get('id')
+        
+    def get_PlaylistID(playlist_name:str) -> PlaylistID|None:
+        playlists = SimpleRequests.get_user_playlists()
+        if type(playlists) is list:
+            for playlist in playlists:
+                if playlist['name'] == playlist_name:
+                    return PlaylistID(playlist['id'])
+        return None
+
+    def get_user_playlists() -> list|None:
+        """
+        TODO: only capable of getting the first 50 playlists, atm  
+        https://developer.spotify.com/documentation/web-api/reference/get-a-list-of-current-users-playlists
+        """
+        SpotifyAuth.Validate_Access_Token()
+        response = requests.get('https://api.spotify.com/v1/me/playlists?limit=50', headers={
+            'Authorization': f'Bearer {Env.Vars['access_token']}'
+        })
+
+        if response.status_code == 200:
+            return response.json()['items']
+        else:
+            Log.Error(SimpleRequests, f'get_user_playlists()\nresponse.status_code: {response.status_code}\nerror message: {response.json().get('error').get('message')}')
+
+    def create_playlist(playlist_name, description="", public=True) -> PlaylistID|str:
+        """
+        https://developer.spotify.com/documentation/web-api/reference/create-playlist
+        """
+        SpotifyAuth.Validate_Access_Token()
+        response = requests.post(f'https://api.spotify.com/v1/users/{UserID.Get()}/playlists',
+            headers = {
+                'content-type': 'application/json',
+                'Authorization': f'Bearer {Env.Vars['access_token']}'
+            },
+            json = {
+                'name': playlist_name,
+                'description': description,
+                'public': public
+            }
+        )
+        if response.status_code == 201:
+            return PlaylistID(response.json().get('id'))
+        else:
+            error = f'response.status_code: {response.status_code}\n{response.json().get('error').get('message')}'
+            Log.Error(SimpleRequests, error)
+            return error
+
+
+    type next_url = str
+
+    def get_users_saved_tracks(limit=50, offset=0, url:Optional[str]=None) -> tuple[list[Track], next_url|None]:
+        """
+        https://developer.spotify.com/documentation/web-api/reference/get-users-saved-tracks
+        
+        **Returns:**  Tuple:  
+            - `list[Track]`
+            - `next_url` | `None` - A response has a next field for the next offset, if more tracks exist
+
+        **Example:**
+        ```python
+        Tracks, next = SimpleRequests.get_users_saved_tracks(url="https://api.spotify.com/v1/me/tracks?offset=0&limit=50")
+        while next:
+            tracks, next = SimpleRequests.get_users_saved_tracks(url=next)
+            Tracks += tracks
+        ```
+        """
+        URL = f'https://api.spotify.com/v1/me/tracks?limit={limit}&offset={offset}'
+        if url:
+            URL = url
+
+        SpotifyAuth.Validate_Access_Token()
+
+        response = requests.get(url=URL, headers={
+            'Authorization': f'Bearer {Env.Vars['access_token']}'
+        }).json()
+
+        tracks:list[Track] = []
+        for item in response.get('items'):
+            tracks.append(Track(
+                title  = item['track']['name'],
+                artist = item['track']['artists'][0]['name'],
+                album  = item['track']['album']['name'],
+                id       = item['track']['id'],
+                added_at = item['added_at']
+            ))
+
+        return (tracks, response.get('next', None))
+
+    type occurrences = int
+    @staticmethod
+    def Liked_Songs() -> dict[ISong, occurrences]:
+        """
+        **Requires:**  in `.env` file:
+            - client_secret
+            - client_id
+        """
+        SpotifyAuth.Validate_Access_Token()
+
+        liked_tracks, next = SimpleRequests.get_users_saved_tracks(url="https://api.spotify.com/v1/me/tracks?offset=0&limit=50")
+        while next:
+            tracks, next = SimpleRequests.get_users_saved_tracks(url=next)
+            liked_tracks += tracks
+
+        type occurrences = int
+        liked_songs:dict[ISong, occurrences] = {}
+        for track in liked_tracks:
+            song = ISong(track.title, track.album, track.artist)
+
+            if song in liked_songs: liked_songs[song] = (liked_songs[song] + 1)
+            else:                   liked_songs[song] = 1
+
+        return liked_songs
+
+
+class SaveToPlaylistRequest(IHandleRequest):
+    """
+    See: https://developer.spotify.com/documentation/web-api/reference/add-tracks-to-playlist
+
+    **Example:**
+    ```python
+    SaveToPlaylistRequest.New_Playlist(
+        playlist_name='Her Favorite Songs',
+        description='upper segment of her lifetime_listening_record - songs_I_already_liked'
+    ).Handle(her_favorite_songs).Result()
+    ```
+    """
+
+    def __init__(self, playlistID:PlaylistID=None, playlist_name:str=None):
+        super().__init__()
+        self.playlistID = playlistID
+        self.playlist_name = playlist_name
+    
+    @classmethod
+    def New_Playlist(cls, playlist_name:str, description = "", public=True) -> SaveToPlaylistRequest:
+        result = SimpleRequests.create_playlist(playlist_name, description, public)
+        if type(result) is PlaylistID:
+            return SaveToPlaylistRequest(result, playlist_name)
+        else: raise RuntimeError(f'SaveToPlaylistRequest.New_Playlist(): Cannot Continue. Error:\n{result}')
+
+    @classmethod
+    def Existing_Playlist(cls, identifier:str|PlaylistID) -> SaveToPlaylistRequest:
+        """
+        `identifier` - name of playlist or `PlaylistID`
+        """
+        if type(identifier) is PlaylistID: return SaveToPlaylistRequest(identifier, SimpleRequests.get_PlaylistName(identifier))
+        if type(identifier) is str:
+            request = SaveToPlaylistRequest(playlist_name=identifier)
+            request.playlistID = SimpleRequests.get_PlaylistID(request.playlist_name)
+            if request.playlistID is None:
+                raise RuntimeError(f'SaveToPlaylistRequest: playlist could not be found with name: { request.playlist_name}')
+            return request
+
+    def Handle(self, playlist:list[ISong]) -> Self:
+        """
+        Spotify Web Api supports adding up to 100 songs per request.
+
+        - `self.result` final value can be: `Success|PartialSuccess|Error`
+        """
+        assert_list('playlist', playlist, min_len=1)
+        if not Env.loaded: Env.Load()
+
+        CHUNK = 100
+        song_count = len(playlist)
+        requests_complete = 0
+        total_requests_to_complete = (int)(song_count / CHUNK)
+        last_request_chunk = song_count % 90
+
+        result:True|str = None
+        for requests_complete in range(total_requests_to_complete):
+            lower_bound = requests_complete * CHUNK
+            upper_bound = lower_bound + CHUNK
+            result = self.handle_chunk([song.uri for song in playlist[lower_bound:upper_bound]])
+
+            if result is not True:
+                self.error = result
+                if requests_complete > 0: self.result = Partial(f'{requests_complete*CHUNK}/{song_count} songs added to: {self.playlist_name} [{self.playlistID}]') 
+                return self
+            
+            time.sleep(1)
+            
+        if last_request_chunk > 0:
+            lower_bound = song_count - last_request_chunk
+            uris = [song.uri for song in playlist[lower_bound:]]
+            result = self.handle_chunk(uris)
+
+            if result is not True:
+                self.error = result
+                if requests_complete > 0: self.result = Partial(f'{requests_complete*CHUNK}/{song_count} songs added to: {self.playlist_name} [{self.playlistID}]')
+                else:                     self.result = Failure(f'0/{song_count} were added to: {self.playlist_name} [{self.playlistID}]')
+                return self
+
+        self.result = Success(f'{song_count}/{song_count} songs added to {self.playlist_name} [{self.playlistID}]')
+        return self
+    
+    def handle_chunk(self, uris:list) -> True|str:
+        """ returns `True` or an error message explaining what caused the failure """
+        response = requests.post(f'https://api.spotify.com/v1/playlists/{self.playlistID}/tracks',
+            headers = {
+                'content-type': 'application/json',
+                'Authorization': f'Bearer {Env.Vars['access_token']}'
+            },
+            json = { 'uris': uris }
+        )
+        if response.status_code != 201:
+            return f'response.status_code: {response.status_code}\n{response.json().get('error').get('message')}'
+        return True
+
+    def Result(self, print=True) -> Success|Partial|Failure:
+        """ Tack onto the end of the Builder pattern chain to print the results of the `SaveToPlaylistRequest` """
+        if print:
+            match self.result:
+                case Success(): Print.green(self.result)
+                case Partial(): Print.dark_yellow(self.result)
+                case Failure(): Print.red(self.result)
+        return self.result


### PR DESCRIPTION
# SpotifyAPI 1.0.0 - Python 3.14
The final stable 1.0 "public release" PR - all other 1.0-related PRs rebased/combined here.

### `main.py` - now serves as a showcase/outline, with examples/steps on how-to:
- use `SpotifyUser`/`Spotify_Data_Type` to find statistical insights from one's Extended Streaming History
- use `Spotify WebAPI` component to use Spotify programmatically.

### `definitions.py`:
- `redirect_uri`, `permission_scopes` moved within to allow easy access, custom setup.

### Template `.env` File
- user can setup use of Spotify Web Api via `client_id`, `client_secret` values.

### spotify_auth.py
- module re-written to remove Flask dependency
- greatly simplified, the only "public" method: `SpotifyAuth.Validate_Access_Token()`

## Many Changes Affecting:
- simplifying user experience
- extensive documentation
- sanity update with goal to allow new developers easy diving.